### PR TITLE
Fix upgrade process for InstallRoot

### DIFF
--- a/pkg/tools/chocolateyinstall.ps1
+++ b/pkg/tools/chocolateyinstall.ps1
@@ -9,7 +9,7 @@ $packageArgs = @{
   checksum64             = '82719AEBCC5372643649F1E4BCE0242F0C4A37321703B793E116AD1993F57AE2'
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
-  silentArgs             = '/passive /norestart'
+  silentArgs             = '/qb /norestart'
   validExitCodes         = @(0,3010)
   softwareName           = 'InstallRoot'
 }

--- a/pkg/tools/chocolateyinstall.ps1
+++ b/pkg/tools/chocolateyinstall.ps1
@@ -33,7 +33,7 @@ if ($key.Count -eq 1) {
 elseif ($key.Count -gt 1) {
   Write-Warning "$($key.Count) matches found!"
   Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
-  Write-Warning "This will most likely cause a 1603/1638 failure when installing InkScape."
+  Write-Warning "This will most likely cause a 1603/1638 failure when installing InstallRoot."
   Write-Warning "Please uninstall InstallRoot before installing this package."
 }
 


### PR DESCRIPTION
Fixed the installer process to factor in for the fact that this MSI installer doesn't support upgrades. This works around it by checking InstallRoot is already installed, then removes the previous package before installing the new version.